### PR TITLE
Forgot `git+` in the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 ## Setup
 
 ```
-pip install https://github.com/zac-vh/qopy.git
+pip install git+https://github.com/zac-vh/qopy.git
 ```
 


### PR DESCRIPTION
I forgot to prepend the URL with `git+`, as required by `pip`.
```diff
-pip install https://github.com/zac-vh/qopy.git
+pip install git+https://github.com/zac-vh/qopy.git
```